### PR TITLE
feat: Typography ui

### DIFF
--- a/packages/ui/typography/package.json
+++ b/packages/ui/typography/package.json
@@ -1,0 +1,55 @@
+{
+  "name": "@layer-ui/typography",
+  "version": "0.0.1",
+  "license": "MIT",
+  "exports": {
+    ".": {
+      "import": {
+        "types": "./dist/index.d.mts",
+        "default": "./dist/index.mjs"
+      },
+      "require": {
+        "types": "./dist/index.d.ts",
+        "default": "./dist/index.js"
+      }
+    }
+  },
+  "source": "./src/index.ts",
+  "main": "./dist/index.js",
+  "module": "./dist/index.mjs",
+  "types": "./dist/index.d.ts",
+  "files": [
+    "dist",
+    "README.md"
+  ],
+  "sideEffects": false,
+  "scripts": {
+    "clean": "rm -rf dist",
+    "version": "pnpm version"
+  },
+  "dependencies": {
+    "@radix-ui/react-slot": "^1.1.0",
+    "@layer-lib/react-use-mounted": "workspace:*"
+  },
+  "peerDependencies": {
+    "@types/react": "*",
+    "@types/react-dom": "*",
+    "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+    "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+  },
+  "peerDependenciesMeta": {
+    "@types/react": {
+      "optional": true
+    },
+    "@types/react-dom": {
+      "optional": true
+    }
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/klmhyeonwoo/layer-design-system.git"
+  },
+  "bugs": {
+    "url": "https://github.com/klmhyeonwoo/layer-design-system/issues"
+  }
+}

--- a/packages/ui/typography/src/Typography.tsx
+++ b/packages/ui/typography/src/Typography.tsx
@@ -1,0 +1,23 @@
+import * as React from "react";
+type TextTags = "span" | "p" | "h1" | "h2" | "h3" | "h4" | "h5" | "h6" | "strong" | "em" | "small" | "q" | "u";
+
+type TypographyProps<T extends TextTags = TextTags> = {
+  as?: T;
+  children: string;
+} & Omit<React.HTMLAttributes<HTMLElement>, "color" | "as" | "variant">;
+
+const Typography = React.forwardRef(<T extends TextTags>(props: TypographyProps<T>, ref: React.ForwardedRef<HTMLElement>) => {
+  const { as: Comp = "span" as any, children, ...rest } = props;
+
+  return (
+    <Comp {...rest} ref={ref}>
+      {children}
+    </Comp>
+  );
+});
+
+Typography.displayName = "Typography";
+
+export { Typography };
+
+export type { TypographyProps };

--- a/packages/ui/typography/src/Typography.tsx
+++ b/packages/ui/typography/src/Typography.tsx
@@ -1,13 +1,16 @@
 import * as React from "react";
 type TextTags = "span" | "p" | "h1" | "h2" | "h3" | "h4" | "h5" | "h6" | "strong" | "em" | "small" | "q" | "u";
 
-type TypographyProps<T extends TextTags = TextTags> = {
-  as?: T;
-  children: string;
-} & Omit<React.HTMLAttributes<HTMLElement>, "color" | "as" | "variant">;
+type ElementType<P = any, Tag extends TextTags = TextTags> =
+  | { [K in Tag]: P extends JSX.IntrinsicElements[K] ? K : never }[Tag]
+  | React.ComponentType<P>;
 
-const Typography = React.forwardRef(<T extends TextTags>(props: TypographyProps<T>, ref: React.ForwardedRef<HTMLElement>) => {
-  const { as: Comp = "span" as any, children, ...rest } = props;
+type TypographyProps<E extends ElementType> = { as?: E };
+
+type Props<E extends ElementType> = TypographyProps<E> & Omit<React.HTMLAttributes<HTMLElement>, "color" | "as" | "variant">;
+
+const Typography = React.forwardRef(<T extends ElementType>(props: Props<T>, ref: React.ForwardedRef<HTMLElement>) => {
+  const { as: Comp = "span", children, ...rest } = props;
 
   return (
     <Comp {...rest} ref={ref}>

--- a/packages/ui/typography/src/index.ts
+++ b/packages/ui/typography/src/index.ts
@@ -1,0 +1,3 @@
+"use client";
+export { Typography } from "./Typography";
+export type { TypographyProps } from "./Typography";

--- a/ssr/app/layout.tsx
+++ b/ssr/app/layout.tsx
@@ -22,6 +22,9 @@ export default function RootLayout({
             <Link style={{ border: "1px solid black", borderRadius: "0.5em", padding: "0.2em 1em", backgroundColor: "#cccccc" }} href="/modal">
               Modal
             </Link>
+            <Link style={{ border: "1px solid black", borderRadius: "0.5em", padding: "0.2em 1em", backgroundColor: "#cccccc" }} href="/typography">
+              Typography
+            </Link>
           </div>
           <main style={{ flex: 1 }}>{children}</main>
         </div>

--- a/ssr/app/typography/page.tsx
+++ b/ssr/app/typography/page.tsx
@@ -1,5 +1,20 @@
 import { Typography } from "@layer-ui/typography";
 
 export default function TypographyPage() {
-  return <Typography as="h1">Typography</Typography>;
+  return (
+    <div>
+      <Typography as="h1">H1</Typography>
+      <Typography as="h2">H2</Typography>
+      <Typography as="h3">H3</Typography>
+      <Typography as="h4">H4</Typography>
+      <Typography as="h5">H5</Typography>
+      <Typography as="h6">H6</Typography>
+      <Typography as="p">P</Typography>
+      <Typography as="q">Q</Typography>
+      <Typography as="small">Small</Typography>
+      <Typography as="strong">Strong</Typography>
+      <Typography as="em">Em</Typography>
+      <Typography as="u">U</Typography>
+    </div>
+  );
 }

--- a/ssr/app/typography/page.tsx
+++ b/ssr/app/typography/page.tsx
@@ -1,0 +1,5 @@
+import { Typography } from "@layer-ui/typography";
+
+export default function TypographyPage() {
+  return <Typography as="h1">Typography</Typography>;
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -37,7 +37,8 @@
       "@layer-ui/button": ["./packages/ui/button/src"],
       "@layer-ui/portal": ["./packages/ui/portal/src"],
       "@layer-ui/modal": ["./packages/ui/modal/src"],
-      "@layer-ui/presence": ["./packages/ui/presence/src"]
+      "@layer-ui/presence": ["./packages/ui/presence/src"],
+      "@layer-ui/typography": ["./packages/ui/typography/src"]
     }
   },
   "include": ["demo", "packages", "ssr"]


### PR DESCRIPTION
## Typography 컴포넌트 제작


- `택스트`를 나타내는 컴포넌트를 제작했어요.
- `as` 속성을 통해 택스트를 표현하는 태그를 사용할 수 있어요.




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **New Features**
	- `@layer-ui/typography` 패키지가 추가되어 텍스트 렌더링을 위한 `Typography` 컴포넌트를 제공합니다.
	- 새로운 `/typography` 경로로 연결되는 링크가 `RootLayout`에 추가되었습니다.
	- `TypographyPage` 컴포넌트가 생성되어 다양한 HTML 요소를 표시합니다.

- **Bug Fixes**
	- 없음

- **Documentation**
	- `package.json` 파일에 패키지 메타데이터가 정의되었습니다.

- **Chores**
	- TypeScript 설정에 `@layer-ui/typography` 경로 매핑이 추가되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->