### PR TITLE
refactor(create-context): createContext 사용 시 디버깅에 용이하도록 매개변수 추가

### DIFF
--- a/demo/tsconfig.json
+++ b/demo/tsconfig.json
@@ -21,5 +21,5 @@
     "noUnusedParameters": true,
     "noFallthroughCasesInSwitch": true
   },
-  "include": ["src", "../packages/ui"]
+  "include": ["src", "../packages"]
 }

--- a/demo/tsconfig.json
+++ b/demo/tsconfig.json
@@ -20,6 +20,5 @@
     "noUnusedLocals": true,
     "noUnusedParameters": true,
     "noFallthroughCasesInSwitch": true
-  },
-  "include": ["src", "../packages"]
+  }
 }

--- a/demo/vite.config.ts
+++ b/demo/vite.config.ts
@@ -8,6 +8,7 @@ export default defineConfig({
   resolve: {
     alias: {
       "@layer-ui": path.resolve(__dirname, "../packages/ui"),
+      "@layer-lib": path.resolve(__dirname, "../packages/lib"),
     },
   },
   build: {

--- a/packages/lib/react-context/src/create-context.tsx
+++ b/packages/lib/react-context/src/create-context.tsx
@@ -1,6 +1,6 @@
 import * as React from "react";
 
-function createContext<ContextType extends object | null>(defaultValue?: ContextType) {
+function createContext<ContextType extends object | null>(contextName: string, defaultValue?: ContextType) {
   const Context = React.createContext<ContextType | undefined>(defaultValue);
 
   function Provider(props: ContextType & { children: React.ReactNode }) {
@@ -10,11 +10,13 @@ function createContext<ContextType extends object | null>(defaultValue?: Context
     return <Context.Provider value={values}> {children} </Context.Provider>;
   }
 
-  function useContext() {
+  function useContext(componentName: string) {
     const context = React.useContext(Context);
     if (context) return context;
     if (defaultValue) return defaultValue;
-    throw new Error(`Context 값을 찾을 수 없습니다. useContext는 반드시 해당하는 Provider 내부에서 사용되어야 합니다.`);
+    throw new Error(
+      `${contextName}Context 값을 찾을 수 없습니다. <${componentName} />에서 사용된 ${contextName}context는 반드시 해당하는 ${contextName}Provider 내부에서 사용되어야 합니다.`,
+    );
   }
 
   return [Provider, useContext] as const;

--- a/packages/ui/modal/src/Modal.tsx
+++ b/packages/ui/modal/src/Modal.tsx
@@ -102,7 +102,7 @@ interface ModalContentProps extends React.ComponentPropsWithoutRef<"div"> {}
 
 const ModalContentInner = React.forwardRef<HTMLDivElement, ModalContentProps>((props, forwardedRef) => {
   const { autoFocus = true, ...contentProps } = props;
-  const context = useModalContext("ModalContent");
+  const context = useModalContext("ModalContentInner");
 
   const [focusContainer, setFocusContainer] = React.useState<HTMLElement | null>();
   const previousFocus = React.useRef<HTMLElement | null>(null);

--- a/packages/ui/modal/src/Modal.tsx
+++ b/packages/ui/modal/src/Modal.tsx
@@ -23,7 +23,7 @@ interface ModalContextType {
   trapFocus: boolean;
 }
 
-const [ModalProvider, useModalContext] = createContext<ModalContextType>();
+const [ModalProvider, useModalContext] = createContext<ModalContextType>("Modal");
 
 const getState = (open: boolean) => {
   return open ? "open" : "closed";
@@ -78,7 +78,7 @@ interface ModalTriggerProps extends React.ComponentPropsWithoutRef<"button"> {
 
 const ModalTrigger = React.forwardRef<HTMLButtonElement, ModalTriggerProps>((props, forwardedRef) => {
   const { asChild, ...triggerProps } = props;
-  const context = useModalContext();
+  const context = useModalContext("ModalTrigger");
   const triggerRef = useComposedRef(forwardedRef, context.triggerRef);
   const Component = asChild ? Slot : "button";
 
@@ -102,7 +102,7 @@ interface ModalContentProps extends React.ComponentPropsWithoutRef<"div"> {}
 
 const ModalContentInner = React.forwardRef<HTMLDivElement, ModalContentProps>((props, forwardedRef) => {
   const { autoFocus = true, ...contentProps } = props;
-  const context = useModalContext();
+  const context = useModalContext("ModalContent");
 
   const [focusContainer, setFocusContainer] = React.useState<HTMLElement | null>();
   const previousFocus = React.useRef<HTMLElement | null>(null);
@@ -153,7 +153,7 @@ const ModalContentInner = React.forwardRef<HTMLDivElement, ModalContentProps>((p
 ModalContentInner.displayName = "ModalContentInner";
 
 const ModalContent = React.forwardRef<HTMLDivElement, ModalContentProps>(({ ...contentProps }, forwardedRef) => {
-  const context = useModalContext();
+  const context = useModalContext("ModalContent");
 
   return context.modal ? (
     <ModalPortal>
@@ -171,7 +171,7 @@ ModalContent.displayName = "ModalContent";
 interface ModalPortalProps extends React.ComponentPropsWithoutRef<"div"> {}
 
 const ModalPortal = ({ children, ...portalProps }: ModalPortalProps) => {
-  const context = useModalContext();
+  const context = useModalContext("ModalPortal");
 
   return React.Children.map(children, (child) => (
     <Presence present={context.open}>
@@ -185,7 +185,7 @@ ModalPortal.displayName = "ModalPortal";
 interface ModalOverlayInnerProps extends React.ComponentPropsWithoutRef<"div"> {}
 
 const ModalOverlayInner = React.forwardRef<HTMLDivElement, ModalOverlayInnerProps>(({ ...overlayProps }, forwardedRef) => {
-  const context = useModalContext();
+  const context = useModalContext("ModalOverlayInner");
 
   return (
     <RemoveScroll as={Slot} allowPinchZoom shards={[context.contentRef]}>
@@ -206,7 +206,7 @@ ModalOverlayInner.displayName = "ModalOverlayInner";
 interface ModalOverlayProps extends React.ComponentPropsWithoutRef<"div"> {}
 
 const ModalOverlay = React.forwardRef<HTMLDivElement, ModalOverlayProps>(({ ...overlayProps }, forwardedRef) => {
-  const context = useModalContext();
+  const context = useModalContext("ModalOverlay");
   return context.modal ? (
     <Presence present={context.open}>
       <ModalOverlayInner {...overlayProps} ref={forwardedRef} />


### PR DESCRIPTION
소소하긴 한데.. createContext 사용할 때 디버깅에 용이하도록 매개변수를 추가했어요.

사용처 입장에서도 잘못된 레이어를 사용한 경우 아래와 같은 에러를 만나게 되는데, 
에러 메세지를 통해 문제가 되고 있는 컴포넌트를 쉽게 확인할 수 있을 것을 기대하고 추가했어요.

| as-is | to-be |
|:--:|:--:|
| ![image](https://github.com/user-attachments/assets/e620e457-f827-4669-8c94-2eea98d755ac) |  ![image](https://github.com/user-attachments/assets/823f4085-7029-4f59-8920-c723754132c4) | 




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- 모달 컴포넌트의 컨텍스트 관리 개선: 각 모달 관련 컴포넌트가 자신을 식별할 수 있는 문자열 인자를 사용하여 컨텍스트를 보다 정확하게 관리합니다.
	- Vite 구성에 새로운 별칭 `@layer-ui` 및 `@layer-lib` 추가: UI 및 라이브러리 패키지의 모듈을 쉽게 가져올 수 있게 됩니다.
- **Bug Fixes**
	- 오류 메시지 개선: 컨텍스트가 발견되지 않을 경우, 더 구체적인 정보를 제공하는 오류 메시지가 추가되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->